### PR TITLE
Avoid `pkg-config` by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,43 @@
-SHELL ?= /bin/bash
+SHELL         ?= /bin/bash
+CCLD          ?= $(CC)
+LN            ?= ln
 
+CFLAGS        ?= -g
+CFLAGS        += -D_GNU_SOURCE -Wall -fPIC
 
-LIBNAME = libmlbuf
-LIB_VER_MAJOR = 0
-LIB_VER_MINOR = 0
-LIB_VER_PATCH = 1
-LIB_VER = $(LIB_VER_MAJOR).$(LIB_VER_MINOR).$(LIB_VER_PATCH)
+LDFLAGS       ?=
+LDFLAGS       += -shared
 
+PCRE_LDLIBS   ?= -lpcre
+LDLIBS        ?=
+LDLIBS        += $(PCRE_LDLIBS)
 
-CFLAGS ?= -g
-CCLD   ?= $(CC)
+libname       := libmlbuf
+lib_ver_cur   := 1
+lib_ver_rev   := 0
+lib_ver_age   := 0
+lib_ver       := $(lib_ver_cur).$(lib_ver_rev).$(lib_ver_age)
+srcs          := $(wildcard *.c)
+objs          := $(srcs:.c=.o)
 
-LIBPCRE_CFLAGS  ?= $(shell pkg-config libpcre --cflags)
-LIBPCRE_LDFLAGS ?= $(shell pkg-config libpcre --libs-only-L --libs-only-other)
-LIBPCRE_LDLIBS  ?= $(shell pkg-config libpcre --libs-only-l)
+all: $(libname).so $(libname).a
 
-CFLAGS  += -D_GNU_SOURCE -Wall -fPIC $(LIBPCRE_CFLAGS)
-LDFLAGS += -shared $(LIBPCRE_LDFLAGS)
-LDLIBS  += $(LIBPCRE_LDLIBS)
+$(libname).so: $(objs)
+	$(CCLD) $(LDFLAGS) -Wl,-soname,$(libname).so.$(lib_ver_cur) -o $(libname).so.$(lib_ver) $(objs) $(LDLIBS)
+	$(LN) -s $(libname).so.$(lib_ver) $(libname).so.$(lib_ver_cur).$(lib_ver_rev)
+	$(LN) -s $(libname).so.$(lib_ver) $(libname).so.$(lib_ver_cur)
+	$(LN) -s $(libname).so.$(lib_ver) $(libname).so
 
+$(libname).a: $(objs)
+	$(AR) rcs $(libname).a $(objs)
 
-SRCS := $(wildcard *.c)
-OBJS := $(SRCS:.c=.o)
+$(objs): %.o: %.c
 
-
-all: $(LIBNAME).so $(LIBNAME).a
-
-$(LIBNAME).so: $(OBJS)
-	$(CCLD) $(LDFLAGS) -Wl,-soname,$(LIBNAME).so.$(LIB_VER_MAJOR) -o $(LIBNAME).so.$(LIB_VER) $(OBJS) $(LDLIBS)
-	ln -s $(LIBNAME).so.$(LIB_VER) $(LIBNAME).so.$(LIB_VER_MAJOR).$(LIB_VER_MINOR)
-	ln -s $(LIBNAME).so.$(LIB_VER) $(LIBNAME).so.$(LIB_VER_MAJOR)
-	ln -s $(LIBNAME).so.$(LIB_VER) $(LIBNAME).so
-
-$(LIBNAME).a: $(OBJS)
-	$(AR) rcs $(LIBNAME).a $(OBJS)
-
-$(OBJS): %.o: %.c
-
-test: $(LIBNAME).so
+test: $(libname).so
 	$(MAKE) -C tests
 
 clean:
-	$(RM) -f *.o $(LIBNAME).a $(LIBNAME).so*
+	$(RM) -f *.o $(libname).a $(libname).so*
 	$(MAKE) -C tests clean
 
 .PHONY: all test clean


### PR DESCRIPTION
`pkg-config` breaks the way I personally build mle so I'd rather not make it the default. Otherwise fine by me. If this works for you, update the PR and I'll merge. Thanks!